### PR TITLE
parser.n: output raw forms instead of sbc2dbc() forms

### DIFF
--- a/src/parser.n/io.cpp
+++ b/src/parser.n/io.cpp
@@ -64,7 +64,7 @@ void CoNLLWriter::write(const Instance& inst) {
 
   for (size_t i = 1; i < len; ++ i) {
     f << i << "\t"                  // 0 - index
-      << inst.forms[i]   << "\t"   // 1 - form
+      << inst.raw_forms[i]   << "\t"   // 1 - form
       << inst.lemmas[i]  << "\t"   // 2 - lemma
       << inst.postags[i] << "\t"   // 3 - postag
       << "_\t"   // 4 - unknown
@@ -84,7 +84,7 @@ void CoNLLWriter::write(const Instance& inst, const std::vector<int>& heads,
   size_t len = inst.size();
   for (size_t i = 1; i < len; ++ i) {
     f << i << "\t"                  // 0 - index
-      << inst.forms[i]   << "\t"   // 1 - form
+      << inst.raw_forms[i]   << "\t"   // 1 - form
       << inst.lemmas[i]  << "\t"   // 2 - lemma
       << inst.postags[i] << "\t"   // 3 - postag
       << "_\t"   // 4 - unknown


### PR DESCRIPTION
When predict on GB encoded files, the output text will corrupt on ascii characters. So maybe output raw forms is the solution.

![1](https://cloud.githubusercontent.com/assets/724257/9270947/52939c6a-42a8-11e5-891c-5870992ec19e.png)
