### PR TITLE
issue #110 marginal probability

### DIFF
--- a/src/framework/decoder.h
+++ b/src/framework/decoder.h
@@ -5,6 +5,7 @@
 #include "utils/math/sparsevec.h"
 #include "utils/math/featurevec.h"
 #include "utils/logging.hpp"
+#include "math.h"
 
 namespace ltp {
 namespace framework {
@@ -349,14 +350,14 @@ protected:
 
     for (int i = 0; i < L; ++ i) {
       for (int t = 0; t < T; ++ t) {
-        exp_emit[i][t] = std::exp(scm.emit(i, t) / last_timestamp);
+        exp_emit[i][t] = exp(scm.emit(i, t) / last_timestamp);
       }
     }
 
     exp_tran.resize(T, T);
     for (int i = 0; i < T; ++ i) {
       for (int j = 0; j < T; ++ j) {
-        exp_tran[i][j] = std::exp(scm.tran(i, j) / last_timestamp);
+        exp_tran[i][j] = exp(scm.tran(i, j) / last_timestamp);
       }
     }
   }

--- a/src/framework/decoder.h
+++ b/src/framework/decoder.h
@@ -5,7 +5,7 @@
 #include "utils/math/sparsevec.h"
 #include "utils/math/featurevec.h"
 #include "utils/logging.hpp"
-#include "math.h"
+#include <cmath>
 
 namespace ltp {
 namespace framework {

--- a/src/framework/options.h
+++ b/src/framework/options.h
@@ -24,6 +24,8 @@ struct TestOptions {
   std::string model_file;
   std::string lexicon_file;
   bool evaluate;
+  bool sequence_prob;
+  bool marginal_prob;
 };
 
 struct DumpOptions {

--- a/src/framework/parameter.h
+++ b/src/framework/parameter.h
@@ -254,6 +254,7 @@ public:
         out.write(reinterpret_cast<const char*>(&_last_timestamp), sizeof(unsigned long long));
       } else if (opt == kDumpAveraged) {
         out.write(reinterpret_cast<const char*>(_W_sum), sizeof(double) * _dim);
+        out.write(reinterpret_cast<const char*>(&_last_timestamp), sizeof(unsigned long long));
       } else if (opt == kDumpNonAveraged) {
         out.write(reinterpret_cast<const char*>(_W), sizeof(double) * _dim);
       }
@@ -290,6 +291,7 @@ public:
       } else if (!strncmp(body, "avg", 11)) {
         _W_sum = new double[_dim];
         in.read(reinterpret_cast<char *>(_W_sum), sizeof(double)* _dim);
+        in.read(reinterpret_cast<char *>(&_last_timestamp), sizeof(unsigned long long));
         _W = _W_sum;
         _enable_wrapper = true;
       } else if (!strncmp(body, "nonavg", 11)) {

--- a/src/ner/decoder.h
+++ b/src/ner/decoder.h
@@ -19,6 +19,27 @@ public:
       const std::vector<std::string>& includes);
 
   bool can_tran(const size_t& i, const size_t& j) const;
+
+  size_t size(void) const;
+
+};
+
+class NERViterbiDecoderWithMarginal: public framework::ViterbiDecoderWithMarginal {
+public:
+
+  void decode(const framework::ViterbiScoreMatrix& scm,
+              const framework::ViterbiDecodeConstrain& con,
+              std::vector<int>& output);
+
+  void decode(const framework::ViterbiScoreMatrix& scm,
+              const framework::ViterbiDecodeConstrain& con,
+              std::vector<int>& output,
+              double& sequence_probability,
+              std::vector<double>& point_probabilities,
+              std::vector<double>& partial_probabilities,
+              std::vector<int>& partial_idx,
+              bool avg = false,
+              size_t last_timestamp = 1);
 };
 
 }           //  end for namespace ner

--- a/src/ner/instance.h
+++ b/src/ner/instance.h
@@ -121,6 +121,11 @@ public:
   std::vector< std::string >  entities_tags;
   std::vector< std::string >  predict_entities;
   std::vector< std::string >  predict_entities_tags;
+
+  double                      sequence_probability;
+  std::vector< double >       point_probabilities;
+  std::vector< double >       partial_probabilities;
+  std::vector< int >          partial_idx;
 };
 
 }     //  end for namespace ner

--- a/src/ner/io.cpp
+++ b/src/ner/io.cpp
@@ -93,6 +93,41 @@ void NERWriter::write(const Instance* inst) {
       ofs << std::endl;
     }
   }
+
+  if (sequence_prob) {
+    ofs << inst -> sequence_probability << std::endl;
+  }
+
+  if (marginal_prob) {
+    for (size_t i = 0; i < len; ++ i) {
+      ofs << inst -> point_probabilities[i];
+      if (i + 1 < len) {
+        ofs << "\t";
+      } else {
+        ofs << std::endl;
+      }
+    }
+
+    for (size_t i = 0; i < inst->partial_probabilities.size(); ++ i) {
+      if (i + 1 < inst -> partial_probabilities.size()) {
+        ofs << "("
+            << inst -> partial_idx[i]
+            << ","
+            << inst -> partial_idx[i+1] - 1
+            << "):"
+            << inst -> partial_probabilities[i]
+            << "\t";
+      } else {
+        ofs << "("
+            << inst -> partial_idx[i]
+            << ","
+            << inst -> tagsidx.size() - 1
+            << "):"
+            << inst -> partial_probabilities[i]
+            << std::endl;
+      }
+    }
+  }
 }
 
 

--- a/src/ner/io.h
+++ b/src/ner/io.h
@@ -30,11 +30,16 @@ public:
 
 class NERWriter {
 public:
-  NERWriter(std::ostream & _ofs) : ofs(_ofs) {}
+  NERWriter(std::ostream & _ofs, bool _sequence_prob = false, bool _marginal_prob = false)
+      : ofs(_ofs),
+      sequence_prob(_sequence_prob),
+      marginal_prob(_marginal_prob) {}
 
   void write(const Instance* inst);
 private:
   std::ostream & ofs;
+  bool sequence_prob;
+  bool marginal_prob;
 };
 
 }       //  end for namespace ner

--- a/src/ner/ner.cpp
+++ b/src/ner/ner.cpp
@@ -54,8 +54,8 @@ void NamedEntityRecognizer::build_glob_tran_cons(
     }
   }
 
-  INFO_LOG("build-config: add %d constrains.", includes.size());
-  INFO_LOG("report: number of labels %d", model->num_labels());
+  //INFO_LOG("build-config: add %d constrains.", includes.size());
+  //INFO_LOG("report: number of labels %d", model->num_labels());
   glob_con = new NERTransitionConstrain(model->labels, includes);
 }
 

--- a/src/ner/ner_frontend.h
+++ b/src/ner/ner_frontend.h
@@ -6,6 +6,7 @@
 #include "ner/options.h"
 #include "ner/ner.h"
 #include "utils/unordered_set.hpp"
+#include "ner/decoder.h"
 
 namespace ltp {
 namespace ner {
@@ -17,7 +18,7 @@ using framework::ViterbiScoreMatrix;
 
 class NamedEntityRecognizerFrontend: public NamedEntityRecognizer, Frontend {
 private:
-  ViterbiDecoder decoder;
+  NERViterbiDecoderWithMarginal decoder;
   ViterbiFeatureContext ctx;
   ViterbiScoreMatrix scm;
   std::vector<Instance *> train_dat;
@@ -38,7 +39,9 @@ public:
   //! The testing model constructor.
   NamedEntityRecognizerFrontend(const std::string& model_file,
       const std::string& input_file,
-      bool evaluate);
+      bool evaluate,
+      bool sequence_prob = false,
+      bool marginal_prob = false);
 
   //! The dumping model constructor.
   NamedEntityRecognizerFrontend(const std::string& model_file);

--- a/src/ner/otner.cpp
+++ b/src/ner/otner.cpp
@@ -94,6 +94,8 @@ int test(int argc, const char* argv[]) {
     ("input", value<std::string>(), "The path to the reference file.")
     ("evaluate", value<bool>()->default_value(false),
      "if configured, perform evaluation, input should contain '#' concatenated tag")
+    ("sequence", value<bool>()->default_value(false), "Output the probability of the label sequences")
+    ("marginal", value<bool>()->default_value(false), "Output the marginal probabilities of tags")
     ("help,h", "Show help information");
 
   if (argc == 1) { std::cerr << optparser << std::endl;  return 1; }
@@ -128,8 +130,10 @@ int test(int argc, const char* argv[]) {
   }
 
   bool evaluate = vm["evaluate"].as<bool>();
+  bool sequence_prob = vm["sequence"].as<bool>();
+  bool marginal_prob = vm["marginal"].as<bool>();
 
-  NamedEntityRecognizerFrontend frontend(input_file, model_name, evaluate);
+  NamedEntityRecognizerFrontend frontend(input_file, model_name, evaluate, sequence_prob, marginal_prob);
   frontend.test();
   return 0;
 }

--- a/src/postagger/decoder.cpp
+++ b/src/postagger/decoder.cpp
@@ -93,6 +93,59 @@ bool PostaggerLexicon::load(std::istream& is,
   return (successful = true);
 }
 
+void PostaggerViterbiDecoderWithMarginal::decode(const framework::ViterbiScoreMatrix& scm, std::vector<int>& output) {
+  ViterbiDecoder::decode(scm, output);
+}
+
+void PostaggerViterbiDecoderWithMarginal::decode(const framework::ViterbiScoreMatrix& scm,
+            const framework::ViterbiDecodeConstrain& con,
+            std::vector<int>& output) {
+  ViterbiDecoder::decode(scm, con, output);
+}
+
+void PostaggerViterbiDecoderWithMarginal::decode(const framework::ViterbiScoreMatrix& scm,
+                                                 std::vector<int>& output,
+                                                 double& sequence_probability,
+                                                 std::vector<double>& point_probabilities,
+                                                 bool avg,
+                                                 size_t last_timestamp) {
+  ViterbiDecoder::decode(scm, output);
+
+  if (sequence_prob || marginal_prob) {
+    init_prob_ctx(scm, avg, last_timestamp);
+
+    if (sequence_prob) {
+      calc_sequence_probability(output, sequence_probability);
+    }
+
+    if (marginal_prob) {
+      calc_point_probabilities(output, point_probabilities);
+    }
+  }
+}
+
+void PostaggerViterbiDecoderWithMarginal::decode(const framework::ViterbiScoreMatrix& scm,
+                                                 const framework::ViterbiDecodeConstrain& con,
+                                                 std::vector<int>& output,
+                                                 double& sequence_probability,
+                                                 std::vector<double>& point_probabilities,
+                                                 bool avg,
+                                                 size_t last_timestamp) {
+  ViterbiDecoder::decode(scm, con, output);
+
+  if (sequence_prob || marginal_prob) {
+    init_prob_ctx(scm, con, avg, last_timestamp);
+
+    if (sequence_prob) {
+      calc_sequence_probability(output, sequence_probability);
+    }
+
+    if (marginal_prob) {
+      calc_point_probabilities(output, point_probabilities);
+    }
+  }
+}
+
 }     //  end for namespace postagger
 }     //  end for namespace ltp
 

--- a/src/postagger/decoder.h
+++ b/src/postagger/decoder.h
@@ -33,6 +33,31 @@ public:
   bool load(std::istream& is, const utility::IndexableSmartMap& labels_alphabet);
 };
 
+class PostaggerViterbiDecoderWithMarginal: public framework::ViterbiDecoderWithMarginal {
+public:
+  void decode(const framework::ViterbiScoreMatrix& scm, std::vector<int>& output);
+
+  void decode(const framework::ViterbiScoreMatrix& scm,
+              const framework::ViterbiDecodeConstrain& con,
+              std::vector<int>& output);
+
+  void decode(const framework::ViterbiScoreMatrix& scm,
+              std::vector<int>& output,
+              double& sequence_probability,
+              std::vector<double>& point_probabilities,
+              bool avg = false,
+              size_t last_timestamp = 1);
+
+  void decode(const framework::ViterbiScoreMatrix& scm,
+              const framework::ViterbiDecodeConstrain& con,
+              std::vector<int>& output,
+              double& sequence_probability,
+              std::vector<double>& point_probabilities,
+              bool avg = false,
+              size_t last_timestamp = 1);
+
+};
+
 
 }       //  end for namespace postagger
 }       //  end for namespace ltp

--- a/src/postagger/instance.h
+++ b/src/postagger/instance.h
@@ -51,6 +51,9 @@ public:
   std::vector< std::string >  predict_tags;
   std::vector< int >          predict_tagsidx;
 
+  double                      sequence_probability;
+  std::vector< double >       point_probabilities;
+
   std::vector< Bitset >       postag_constrain;   /*< the postag constrain for decode */
 };
 

--- a/src/postagger/io.cpp
+++ b/src/postagger/io.cpp
@@ -61,20 +61,33 @@ Instance* PostaggerReader::next() {
   return inst;
 }
 
-PostaggerWriter::PostaggerWriter(std::ostream& _ofs): ofs(_ofs) {}
-
 void PostaggerWriter::write(const Instance* inst) {
-  int len = inst->size();
+  size_t len = inst->size();
   if (inst->predict_tags.size() != len) {
     return;
   }
 
-  for (int i = 0; i < len; ++ i) {
+  for (size_t i = 0; i < len; ++ i) {
     ofs << inst->raw_forms[i] << "/" << inst->predict_tags[i];
     if (i + 1 < len) {
       ofs << "\t";
     } else {
       ofs << std::endl;
+    }
+  }
+
+  if (sequence_prob) {
+    ofs << inst -> sequence_probability << std::endl;
+  }
+
+  if (marginal_prob) {
+    for (size_t i = 0; i < len; ++ i) {
+      ofs << inst -> point_probabilities[i];
+      if (i + 1 < len) {
+        ofs << "\t";
+      } else {
+        ofs << std::endl;
+      }
     }
   }
 }

--- a/src/postagger/io.h
+++ b/src/postagger/io.h
@@ -24,8 +24,11 @@ public:
 class PostaggerWriter {
 private:
   std::ostream& ofs;
+  bool sequence_prob;
+  bool marginal_prob;
 public:
-  PostaggerWriter(std::ostream & _ofs);
+  PostaggerWriter(std::ostream & _ofs, bool _sequence_prob = false, bool _marginal_prob = false)
+      :ofs(_ofs), sequence_prob(_sequence_prob), marginal_prob(_marginal_prob) {}
   void write(const Instance* inst);
 };
 

--- a/src/postagger/otpos.cpp
+++ b/src/postagger/otpos.cpp
@@ -93,6 +93,8 @@ int test(int argc, const char* argv[]) {
     ("input", value<std::string>(), "The path to the reference file.")
     ("evaluate", value<bool>()->default_value(false),
      "if configured, perform evaluation, input should contain '_' concatenated tag")
+    ("sequence", value<bool>()->default_value(false), "Output the probability of the label sequences")
+    ("marginal", value<bool>()->default_value(false), "Output the marginal probabilities of tags")
     ("help,h", "Show help information");
 
   if (argc == 1) { std::cerr << optparser << std::endl; return 1; }
@@ -128,8 +130,10 @@ int test(int argc, const char* argv[]) {
   if (vm.count("output")) { output_file = vm["output"].as<std::string>(); }
 
   bool evaluate = vm["evaluate"].as<bool>();
+  bool sequence_prob = vm["sequence"].as<bool>();
+  bool marginal_prob = vm["marginal"].as<bool>();
 
-  PostaggerFrontend frontend(input_file, model_file, lexicon_file, evaluate);
+  PostaggerFrontend frontend(input_file, model_file, lexicon_file, evaluate, sequence_prob, marginal_prob);
   frontend.test();
   return 0;
 }

--- a/src/postagger/postagger_frontend.h
+++ b/src/postagger/postagger_frontend.h
@@ -5,6 +5,7 @@
 #include "framework/frontend.h"
 #include "postagger/options.h"
 #include "postagger/postagger.h"
+#include "postagger/decoder.h"
 // #include "postagger/constrainutil.hpp"
 
 namespace ltp {
@@ -12,7 +13,7 @@ namespace postagger {
 
 class PostaggerFrontend: public Postagger, framework::Frontend {
 private:
-  framework::ViterbiDecoder decoder;            //! The decoder.
+  PostaggerViterbiDecoderWithMarginal decoder;            //! The decoder.
   framework::ViterbiFeatureContext ctx;         //! The decode context
   framework::ViterbiScoreMatrix scm;            //! The score matrix
   std::vector<Instance *> train_dat;  //! The training data.
@@ -32,7 +33,9 @@ public:
   PostaggerFrontend(const std::string& input_file,
       const std::string& model_file,
       const std::string& lexicon_file,
-      bool evaluate);
+      bool evaluate,
+      bool sequence_prob = false,
+      bool marginal_prob = false);
 
   PostaggerFrontend(const std::string& model_file);
 

--- a/src/segmentor/decoder.cpp
+++ b/src/segmentor/decoder.cpp
@@ -42,6 +42,47 @@ bool PartialSegmentationConstrain::can_emit(const size_t& i, const size_t& j) co
   return (mat[i] & (1<<j));
 }
 
+void SegmentationViterbiDecoderWithMarginal::decode(const framework::ViterbiScoreMatrix& scm,
+            const framework::ViterbiDecodeConstrain& con,
+            std::vector<int>& output) {
+  ViterbiDecoder::decode(scm, con, output);
+}
+
+
+void SegmentationViterbiDecoderWithMarginal::decode(const framework::ViterbiScoreMatrix& scm,
+        const framework::ViterbiDecodeConstrain& con,
+        std::vector<int>& output,
+        double& sequence_probability,
+        std::vector<double>& point_probabilities,
+        std::vector<double>& partial_probabilities,
+        std::vector<int>& partial_idx,
+        bool avg,
+        size_t last_timestamp) {
+
+  ViterbiDecoder::decode(scm, con, output);
+
+  if (sequence_prob || marginal_prob) {
+    init_prob_ctx(scm, con, avg, last_timestamp);
+
+    if (sequence_prob) {
+      calc_sequence_probability(output, sequence_probability);
+    }
+
+    if (marginal_prob) {
+      calc_point_probabilities(output, point_probabilities);
+
+      for (size_t i = 0; i < output.size(); ++i) {
+        if (output[i] == __b_id__ || output[i] == __s_id__) {
+          partial_idx.push_back(i);
+        }
+      }
+
+      calc_partial_probabilities(output, partial_idx, partial_probabilities);
+
+    }
+  }
+}
+
 }     //  end for namespace segmentor
 }     //  end for namespace ltp
 

--- a/src/segmentor/decoder.h
+++ b/src/segmentor/decoder.h
@@ -33,6 +33,24 @@ public:
   bool can_emit(const size_t& i, const size_t& j) const;
 };
 
+class SegmentationViterbiDecoderWithMarginal: public framework::ViterbiDecoderWithMarginal {
+public:
+
+  void decode(const framework::ViterbiScoreMatrix& scm,
+              const framework::ViterbiDecodeConstrain& con,
+              std::vector<int>& output);
+
+  void decode(const framework::ViterbiScoreMatrix& scm,
+              const framework::ViterbiDecodeConstrain& con,
+              std::vector<int>& output,
+              double& sequence_probability,
+              std::vector<double>& point_probabilities,
+              std::vector<double>& partial_probabilities,
+              std::vector<int>& partial_idx,
+              bool avg = false,
+              size_t last_timestamp = 1);
+};
+
 }       //  end for namespace segmentor
 }       //  end for namespace ltp
 #endif    //  end for __LTP_SEGMENTOR_DECODER_H__

--- a/src/segmentor/instance.h
+++ b/src/segmentor/instance.h
@@ -30,6 +30,11 @@ public:
   std::vector< int >          predict_tagsidx;
   std::vector< std::string >  words; // words of the input
   std::vector< std::string >  predict_words;
+
+  double                      sequence_probability;
+  std::vector< double >       point_probabilities;
+  std::vector< double >       partial_probabilities;
+  std::vector< int >          partial_idx;
 };
 
 class InstanceUtils {

--- a/src/segmentor/io.cpp
+++ b/src/segmentor/io.cpp
@@ -82,7 +82,6 @@ Instance* SegmentReader::next() {
   return inst;
 }
 
-SegmentWriter::SegmentWriter(std::ostream& _ofs): ofs(_ofs) {}
 
 void SegmentWriter::write(const Instance* inst) {
   size_t len = inst->predict_words.size();
@@ -90,6 +89,41 @@ void SegmentWriter::write(const Instance* inst) {
     ofs << inst->predict_words[i];
     if (i+1==len) ofs << std::endl;
     else ofs << "\t";
+  }
+
+  if (sequence_prob) {
+    ofs << inst -> sequence_probability << std::endl;
+  }
+
+  if (marginal_prob) {
+    for (size_t i = 0; i < len; ++ i) {
+      ofs << inst -> point_probabilities[i];
+      if (i + 1 < len) {
+        ofs << "\t";
+      } else {
+        ofs << std::endl;
+      }
+    }
+
+    for (size_t i = 0; i < inst->partial_probabilities.size(); ++ i) {
+      if (i + 1 < inst -> partial_probabilities.size()) {
+        ofs << "("
+            << inst -> partial_idx[i]
+            << ","
+            << inst -> partial_idx[i+1] - 1
+            << "):"
+            << inst -> partial_probabilities[i]
+            << "\t";
+      } else {
+        ofs << "("
+            << inst -> partial_idx[i]
+            << ","
+            << inst -> tagsidx.size() - 1
+            << "):"
+            << inst -> partial_probabilities[i]
+            << std::endl;
+      }
+    }
   }
 }
 

--- a/src/segmentor/io.h
+++ b/src/segmentor/io.h
@@ -28,8 +28,13 @@ public:
 class SegmentWriter {
 private:
   std::ostream& ofs;
+  bool sequence_prob;
+  bool marginal_prob;
 public:
-  SegmentWriter(std::ostream& ofs);
+  SegmentWriter(std::ostream& _ofs, bool _sequence_prob=false, bool _marginal_prob=false)
+      : ofs(_ofs),
+      sequence_prob(_sequence_prob),
+      marginal_prob(_marginal_prob) {}
 
   void write(const Instance* inst);
   void debug(const Instance* inst);

--- a/src/segmentor/otcws.cpp
+++ b/src/segmentor/otcws.cpp
@@ -101,6 +101,8 @@ int test(int argc, const char* argv[]) {
     ("input", value<std::string>(), "The path to the reference file.")
     ("evaluate", value<bool>()->default_value(false),
      "if configured, perform evaluation, input words in sentence should be separated by space [default=false].")
+    ("sequence", value<bool>()->default_value(false), "Output the probability of the label sequences")
+    ("marginal", value<bool>()->default_value(false), "Output the marginal probabilities of tags")
     ("help,h", "Show help information");
 
   if (argc == 1) { std::cerr << optparser << std::endl;  return 1; }
@@ -136,8 +138,10 @@ int test(int argc, const char* argv[]) {
   if (vm.count("output")) { output_file = vm["output"].as<std::string>(); }
 
   bool evaluate = vm["evaluate"].as<bool>();
+  bool sequence_prob = vm["sequence"].as<bool>();
+  bool marginal_prob = vm["marginal"].as<bool>();
 
-  SegmentorFrontend frontend(input_file, model_file, evaluate);
+  SegmentorFrontend frontend(input_file, model_file, evaluate, sequence_prob, marginal_prob);
   frontend.test();
   return 0;
 }

--- a/src/segmentor/segmentor_frontend.h
+++ b/src/segmentor/segmentor_frontend.h
@@ -13,7 +13,7 @@ namespace segmentor {
 
 class SegmentorFrontend: public Segmentor, public framework::Frontend {
 protected:
-  framework::ViterbiDecoder decoder;     //! The decoder.
+  SegmentationViterbiDecoderWithMarginal decoder;     //! The decoder.
   framework::ViterbiFeatureContext ctx;  //! The decode context
   framework::ViterbiScoreMatrix scm;     //! The score matrix
   std::vector<const Model::lexicon_t*> lexicons;
@@ -45,7 +45,9 @@ public:
 
   SegmentorFrontend(const std::string& input_file,
       const std::string& model_file,
-      bool evaluate);
+      bool evaluate,
+      bool sequence_prob = false,
+      bool marginal_prob = false);
 
   SegmentorFrontend(const std::string& model_file);
 


### PR DESCRIPTION
由于在参数选项为`kDumpAveraged`的模型中添加了`_last_timestamp`值，所以需要重新训练模型。

在pku词性标注下，基于感知器的marginal probability和[CRFsuite](http://www.chokkan.org/software/crfsuite/)的marginal probability的Pearson相关系数如下：

  |  相关系数
------------ | -------------
sequence probability | 0.94
point probability | 0.78