### PR TITLE
修正全角空格的bug

### DIFF
--- a/src/segmentor/preprocessor.cpp
+++ b/src/segmentor/preprocessor.cpp
@@ -184,9 +184,15 @@ int Preprocessor::preprocess(const std::string& sentence,
         width = 1;
       }
       else if ((sent[i]&0xE0)==0xC0) { width = 2; }
-      else if ((sent[i]&0xF0)==0xE0) { width = 3; }
+      else if ((sent[i]&0xF0)==0xE0) { 
+          width = 3; 
+          if (i + 3 <= len && sent[i] == 0xffffffe3 && sent[i + 1] == 0xffffff80 && sent[i + 2] == 0xffffff80) {
+              is_space = true;
+          }
+      }
       else if ((sent[i]&0xF8)==0xF0) { width = 4; }
       else { return -1; }
+
 
       if (is_space) {
         left_status = HAS_SPACE_ON_LEFT;


### PR DESCRIPTION
preprocess.cpp不能正确处理全角的空格，bug例子如下：
"　台北真的是天子骄子吗？"（句子开头有个全角空格）

分词和词性标注之后的结果：

　/v|台北/ns|真/a|的/u|是/v|天子骄子/n|吗/u|？/wp

修正之后的结果是

台北/ns|真/a|的/u|是/v|天子骄子/n|吗/u|？/wp