### PR TITLE
use xml as default response format  in ltp_server

### DIFF
--- a/src/server/ltp_server.cpp
+++ b/src/server/ltp_server.cpp
@@ -521,10 +521,12 @@ static int Service(struct mg_connection *conn) {
     TRACE_LOG("Analysis is done.");
 
     std::string strResult;
-    if (str_format == "xml") {
+    if (str_format == "xml") { //xml
       xml4nlp.SaveDOM(strResult);
-    } else { //json
+    } else if (str_format == "json") { //json
       strResult = xml2jsonstr(xml4nlp, str_type);
+    } else {  // if str_format not set, or is invalid, use xml
+      xml4nlp.SaveDOM(strResult);
     }
 
 


### PR DESCRIPTION
- before 3.4.0: xml is the only reponse fomrat
- 3.4.0: xml, json (default)
- after 3.4.0: use xml as default instead of json, for compatibility