### PR TITLE
Revert "Load segment lexicon in SBC"

### DIFF
--- a/src/segmentor/segmentor.cpp
+++ b/src/segmentor/segmentor.cpp
@@ -236,32 +236,10 @@ void Segmentor::load_lexicon(const char* filename, Model::lexicon_t* lexicon) co
     return;
   }
   std::string line;
-  bool updated;
-  std::string full;
-  std::string tmp;
   while (std::getline(ifs, line)) {
     trim(line);
     std::string form = line.substr(0, line.find_first_of(" \t"));
-    updated = false;
-    for(int index=0; index<form.size();) {
-      if((form[index] & 0x80) == 0) {
-        if(!updated)
-          full = form.substr(0, index);
-        strutils::chartypes::sbc2dbc(form.substr(index, 1), tmp);
-        full += tmp;
-        index += 1;
-        updated = true;
-      } else if ((form[index] & 0xE0) == 0xC0) index += 2;
-      else if ((form[index] & 0xF0) == 0xE0) index += 3;
-      else if ((form[index] & 0xF8) == 0xF0) index += 4;
-      else if ((form[index] & 0xFC) == 0xF8) index += 5;
-      else if ((form[index] & 0xFE) == 0xFC) index += 6;
-      else {
-        ERROR_LOG("Unknown character prefix : 0x%x @ %s\n", form[index], form.c_str());
-        continue;
-      }
-    }
-    lexicon->set(updated?full.c_str():form.c_str(), true);
+    lexicon->set(form.c_str(), true);
   }
   INFO_LOG("loaded %d lexicon entries", lexicon->size());
 }


### PR DESCRIPTION
Reverts HIT-SCIR/ltp#255
@colbot
目前这个功能的提交有些问题，暂时回退了。
1. 流程上，仅改动加载词表是没有意义的，会导致词表和输入文本不匹配的问题。
2. 逻辑上有bug，出现单字符字之后的部分会被忽略，比如“超A级”。