### PR TITLE
fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/HIT-SCIR/ltp.git ltp \
-	&& cd ltp && ./configure && make -j "$(nproc)" \
+	&& cd ltp && git checkout 3.X && ./configure && make -j "$(nproc)" \
 	 && mv bin/ltp_server / && mv lib/libdynet.so /usr/lib/ && cd / && rm -fr ltp
 
 RUN curl --silent -o ltp_data.zip http://ospm9rsnd.bkt.clouddn.com/model/ltp_data_v3.4.0.zip \


### PR DESCRIPTION
fix build error:
"Cloning into 'ltp'...                                                                                                                
/bin/sh: 1: ./configure: not found "
cause of master branch doesn't exist 'configure' file