### PR TITLE
修正 PyTorch 1.8 兼容性问题 / PyTorch 1.8 compatability fix

### DIFF
--- a/ltp/data/utils/collate.py
+++ b/ltp/data/utils/collate.py
@@ -3,9 +3,16 @@
 # Author: Yunlong Feng <ylfeng@ir.hit.edu.cn>
 
 import torch
-from torch._six import int_classes, string_classes, container_abcs
+from torch._six import string_classes
 from torch.utils.data._utils.collate import np_str_obj_array_pattern, default_collate_err_msg_format
 
+_TORCH_MAJOR, _TORCH_MINOR = map(int, torch.__version__.split('.')[0:2])
+
+if _TORCH_MAJOR < 1 or (_TORCH_MAJOR == 1 and _TORCH_MINOR < 8):
+    from torch._six import int_classes, container_abcs
+else:
+    int_classes = int
+    import collections.abc as container_abcs
 
 def collate(batch):
     r"""Puts each data field into a tensor with outer dimension batch size"""

--- a/ltp/utils/convertor.py
+++ b/ltp/utils/convertor.py
@@ -3,7 +3,13 @@
 # Author: Yunlong Feng <ylfeng@ir.hit.edu.cn>
 
 import torch
-from torch._six import container_abcs
+
+_TORCH_MAJOR, _TORCH_MINOR = map(int, torch.__version__.split('.')[0:2])
+
+if _TORCH_MAJOR < 1 or (_TORCH_MAJOR == 1 and _TORCH_MINOR < 8):
+    from torch._six import container_abcs
+else:
+    import collections.abc as container_abcs
 
 
 def map2device(batch, device=torch.device('cpu')):


### PR DESCRIPTION
PyTorch 1.8 has removed some unused Python 2/3 compatibility code. This change makes some imports from `pytorch._six` invalid.

Ref. https://github.com/pytorch/pytorch/commit/58eb23378f2a376565a66ac32c93a316c45b6131#diff-b3c160475f0fbe8ad50310f92d3534172ba98203387a962b7dc8f4a23b15cf4d