### PR TITLE
fix `(string|int)_classes` and `container_abcs` importing

### DIFF
--- a/ltp/data/utils/collate.py
+++ b/ltp/data/utils/collate.py
@@ -2,17 +2,14 @@
 # -*- coding: utf-8 -*_
 # Author: Yunlong Feng <ylfeng@ir.hit.edu.cn>
 
+import collections.abc as container_abcs
+
 import torch
-from torch._six import string_classes
 from torch.utils.data._utils.collate import np_str_obj_array_pattern, default_collate_err_msg_format
 
-_TORCH_MAJOR, _TORCH_MINOR = map(int, torch.__version__.split('.')[0:2])
+int_classes = int
+string_classes = (str, bytes)
 
-if _TORCH_MAJOR < 1 or (_TORCH_MAJOR == 1 and _TORCH_MINOR < 8):
-    from torch._six import int_classes, container_abcs
-else:
-    int_classes = int
-    import collections.abc as container_abcs
 
 def collate(batch):
     r"""Puts each data field into a tensor with outer dimension batch size"""

--- a/ltp/utils/convertor.py
+++ b/ltp/utils/convertor.py
@@ -2,14 +2,9 @@
 # -*- coding: utf-8 -*_
 # Author: Yunlong Feng <ylfeng@ir.hit.edu.cn>
 
+import collections.abc as container_abcs
+
 import torch
-
-_TORCH_MAJOR, _TORCH_MINOR = map(int, torch.__version__.split('.')[0:2])
-
-if _TORCH_MAJOR < 1 or (_TORCH_MAJOR == 1 and _TORCH_MINOR < 8):
-    from torch._six import container_abcs
-else:
-    import collections.abc as container_abcs
 
 
 def map2device(batch, device=torch.device('cpu')):


### PR DESCRIPTION
According to the source code of torch1.6, `string_classes` is `(str, bytes)`, while `int_classes` is simply `int`.
And, `container_abcs` is `collections.abc`.
We could simply change these importing to fit higher versions of torch.

https://github.com/pytorch/pytorch/blob/f02753fabb8116ab202fd56b3fcaf9389b7cade6/torch/_six.py#L31-L35