### PR TITLE
fix: modle load by PathLike

### DIFF
--- a/python/interface/ltp/interface.py
+++ b/python/interface/ltp/interface.py
@@ -85,7 +85,7 @@ def LTP(
     model_id = pretrained_model_name_or_path
 
     revision = None
-    if len(model_id.split("@")) == 2:
+    if isinstance(model_id, str) and len(model_id.split("@")) == 2:
         model_id, revision = model_id.split("@")
 
     if os.path.isdir(model_id) and CONFIG_NAME in os.listdir(model_id):

--- a/python/interface/ltp/mixin.py
+++ b/python/interface/ltp/mixin.py
@@ -107,7 +107,7 @@ class ModelHubMixin:
         model_id = pretrained_model_name_or_path
 
         revision = None
-        if len(model_id.split("@")) == 2:
+        if isinstance(model_id, str) and len(model_id.split("@")) == 2:
             model_id, revision = model_id.split("@")
 
         if os.path.isdir(model_id) and CONFIG_NAME in os.listdir(model_id):


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fix when load model by PathLike dir. Obviously, only str can be split.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
