### PR TITLE
🔧  fix: replace deprecated use_auth_token with token for huggingface_h…

### DIFF
--- a/python/interface/ltp/interface.py
+++ b/python/interface/ltp/interface.py
@@ -14,7 +14,7 @@ def LTP(
     pretrained_model_name_or_path="LTP/small",
     force_download: bool = False,
     proxies: Dict = None,
-    use_auth_token: Optional[str] = None,
+    token: Optional[str] = None,
     cache_dir: Optional[str] = None,
     local_files_only: bool = False,
     **model_kwargs,
@@ -59,7 +59,7 @@ def LTP(
                     endpoint, e.g., `{'http': 'foo.bar:3128',
                     'http://hostname': 'foo.bar:4012'}`. The proxies are
                     used on each request.
-                use_auth_token (`str` or `bool`, *optional*):
+                token (`str` or `bool`, *optional*):
                     The token to use as HTTP bearer authorization for remote
                     files. If `True`, will use the token generated when
                     running `transformers-cli login` (stored in
@@ -77,7 +77,7 @@ def LTP(
 
             <Tip>
 
-            Passing `use_auth_token=True` is required when you want to use a
+            Passing `token=True` is required when you want to use a
             private model.
 
             </Tip>
@@ -102,7 +102,7 @@ def LTP(
                 cache_dir=cache_dir,
                 force_download=force_download,
                 proxies=proxies,
-                use_auth_token=use_auth_token,
+                token=token,
                 local_files_only=local_files_only,
             )
         except RequestException:
@@ -124,7 +124,7 @@ def LTP(
             force_download,
             proxies,
             local_files_only,
-            use_auth_token,
+            token,
             **model_kwargs,
         )
     else:
@@ -135,6 +135,6 @@ def LTP(
             force_download,
             proxies,
             local_files_only,
-            use_auth_token,
+            token,
             **model_kwargs,
         )

--- a/python/interface/ltp/legacy.py
+++ b/python/interface/ltp/legacy.py
@@ -133,7 +133,7 @@ class LTP(ModelHubMixin):
         force_download,
         proxies,
         local_files_only,
-        use_auth_token,
+        token,
         **model_kwargs,
     ):
         """Overwrite this method in case you wish to initialize your model in a different way."""
@@ -152,7 +152,7 @@ class LTP(ModelHubMixin):
                     cache_dir=cache_dir,
                     force_download=force_download,
                     proxies=proxies,
-                    use_auth_token=use_auth_token,
+                    token=token,
                     local_files_only=local_files_only,
                 )
                 for task, model_file in model_kwargs["config"]["tasks"].items()

--- a/python/interface/ltp/mixin.py
+++ b/python/interface/ltp/mixin.py
@@ -32,7 +32,7 @@ class ModelHubMixin:
         force_download: bool = False,
         resume_download: bool = False,
         proxies: Dict = None,
-        use_auth_token: Optional[str] = None,
+        token: Optional[str] = None,
         cache_dir: Optional[str] = None,
         local_files_only: bool = False,
         **model_kwargs,
@@ -80,7 +80,7 @@ class ModelHubMixin:
                         endpoint, e.g., `{'http': 'foo.bar:3128',
                         'http://hostname': 'foo.bar:4012'}`. The proxies are
                         used on each request.
-                    use_auth_token (`str` or `bool`, *optional*):
+                    token (`str` or `bool`, *optional*):
                         The token to use as HTTP bearer authorization for remote
                         files. If `True`, will use the token generated when
                         running `transformers-cli login` (stored in
@@ -98,7 +98,7 @@ class ModelHubMixin:
 
                 <Tip>
 
-                Passing `use_auth_token=True` is required when you want to use a
+                Passing `token=True` is required when you want to use a
                 private model.
 
                 </Tip>
@@ -124,7 +124,7 @@ class ModelHubMixin:
                     force_download=force_download,
                     proxies=proxies,
                     resume_download=resume_download,
-                    use_auth_token=use_auth_token,
+                    token=token,
                     local_files_only=local_files_only,
                 )
             except requests.exceptions.RequestException:
@@ -146,7 +146,7 @@ class ModelHubMixin:
             proxies,
             resume_download,
             local_files_only,
-            use_auth_token,
+            token,
             **model_kwargs,
         )
 
@@ -160,7 +160,7 @@ class ModelHubMixin:
         proxies,
         resume_download,
         local_files_only,
-        use_auth_token,
+        token,
         **model_kwargs,
     ):
         """Overwrite this method in subclass to define how to load your model from pretrained."""

--- a/python/interface/ltp/nerual.py
+++ b/python/interface/ltp/nerual.py
@@ -512,7 +512,7 @@ class LTP(BaseModule, ModelHubMixin):
         force_download,
         proxies,
         local_files_only,
-        use_auth_token,
+        token,
         map_location="cpu",
         strict=False,
         **model_kwargs,
@@ -533,7 +533,7 @@ class LTP(BaseModule, ModelHubMixin):
                 cache_dir=cache_dir,
                 force_download=force_download,
                 proxies=proxies,
-                use_auth_token=use_auth_token,
+                token=token,
                 local_files_only=local_files_only,
             )
             tokenizer = AutoTokenizer.from_pretrained(
@@ -543,7 +543,7 @@ class LTP(BaseModule, ModelHubMixin):
                 cache_dir=cache_dir,
                 force_download=force_download,
                 proxies=proxies,
-                use_auth_token=use_auth_token,
+                token=token,
                 local_files_only=local_files_only,
                 use_fast=True,
             )


### PR DESCRIPTION
## What does this PR do?

This PR replaces the deprecated `use_auth_token` argument with the new `token` parameter in `hf_hub_download`.

Recent versions of `huggingface_hub` removed support for `use_auth_token`, which caused a `TypeError` during model download. This change ensures compatibility with the latest versions of the library while preserving existing functionality.

## Changes

- Replaced `use_auth_token` with `token` in all `hf_hub_download` calls

## Testing

- Verified model loading works with the latest `huggingface_hub`

